### PR TITLE
FIX: Update nepali-date-picker to version 2.0.2

### DIFF
--- a/nepali_datetime_field/forms.py
+++ b/nepali_datetime_field/forms.py
@@ -10,11 +10,11 @@ class NepaliDateInput(forms.DateInput):
 
     class Media:
         css = {
-            'all': ('https://unpkg.com/nepali-date-picker@2.0.1/dist/nepaliDatePicker.min.css',)
+            'all': ('https://unpkg.com/nepali-date-picker@2.0.2/dist/nepaliDatePicker.min.css',)
         }
         js = (
             'https://code.jquery.com/jquery-3.5.1.slim.min.js',
-            'https://unpkg.com/nepali-date-picker@2.0.1/dist/jquery.nepaliDatePicker.min.js',
+            'https://unpkg.com/nepali-date-picker@2.0.2/dist/jquery.nepaliDatePicker.min.js',
             'nepali_datetime_field/init.js',
         )
 

--- a/nepali_datetime_field/forms.py
+++ b/nepali_datetime_field/forms.py
@@ -14,7 +14,7 @@ class NepaliDateInput(forms.DateInput):
         }
         js = (
             'https://code.jquery.com/jquery-3.5.1.slim.min.js',
-            'https://unpkg.com/nepali-date-picker@2.0.2/dist/jquery.nepaliDatePicker.min.js',
+            'https://unpkg.com/nepali-date-picker@2.0.2/dist/nepaliDatePicker.min.js',
             'nepali_datetime_field/init.js',
         )
 


### PR DESCRIPTION
This PR introduces the changes to update `nepali-date-picker` to version 2.0.2 in forms.py which has fixes for dates in 2081 BS.
Release link:  https://github.com/leapfrogtechnology/nepali-date-picker/releases/latest